### PR TITLE
Fix platformio.ini for Cranberry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -52,13 +52,13 @@ build_flags = -DGA -DSEN_STUB -DHB_FOREVER
 [env:gc_production]
 platform = atmelavr
 framework = arduino
-board = uno
+board = pro8MHzatmega328
 build_flags = -DGC
 
 [env:gc_stub]
 platform = atmelavr
 framework = arduino
-board = uno
+board = pro8MHzatmega328
 build_flags = -DGC -DSEN_STUB -DHB_FOREVER
 
 


### PR DESCRIPTION
Cranberry runs on 3.3 volts but the Arduino Uno runs on 5 volts.
The platformio.ini was configured with the Uno board for Cranberry.
We were able to use pro8MHzatmega328 because it also runs on 3.3 volts,
and it contains the same microcontroller as the Arduino Uno.