### PR TITLE
Schema update for all generations and heartbeat packet.

### DIFF
--- a/src/gen_apple/ga_board.cpp
+++ b/src/gen_apple/ga_board.cpp
@@ -42,7 +42,7 @@ void ga_board_init(ga_board *b){
     b->prev_sample_ms = 0;
 
     // Initialize the packet
-    b->data_packet.schema = 0;
+    b->data_packet.schema = 1;
     b->data_packet.node_addr = 0;
     b->data_packet.uptime_ms = 0;
     b->data_packet.batt_mv = 0;
@@ -255,7 +255,7 @@ static void ga_board_heartbeat_tx(struct ga_board* b){
     uint8_t payload[_GA_DEV_XBEE_BUFSIZE_];
     struct ga_heartbeat_packet hb_packet;
 
-    hb_packet.schema = 5;
+    hb_packet.schema = 0;
     hb_packet.uptime_ms = millis();
     hb_packet.batt_mv = ga_dev_batt_read();
     hb_packet.node_addr = ga_dev_eeprom_naddr_read();

--- a/src/gen_cranberry/gc_board.cpp
+++ b/src/gen_cranberry/gc_board.cpp
@@ -42,7 +42,7 @@ void gc_board_init(gc_board *b){
     b->prev_sample_ms = 0;
 
     // Initialize the packet
-    b->data_packet.schema = 0;
+    b->data_packet.schema = 2;
     b->data_packet.node_addr = 0;
     b->data_packet.uptime_ms = 0;
     b->data_packet.batt_mv = 0;
@@ -259,7 +259,7 @@ static void gc_board_heartbeat_tx(struct gc_board* b){
     uint8_t payload[_GC_DEV_XBEE_BUFSIZE_];
     struct gc_heartbeat_packet hb_packet;
 
-    hb_packet.schema = 5;
+    hb_packet.schema = 0;
     hb_packet.uptime_ms = millis();
     hb_packet.batt_mv = gc_dev_batt_read();
     hb_packet.node_addr = gc_dev_eeprom_naddr_read();

--- a/src/gen_dragonfruit/gd_board.cpp
+++ b/src/gen_dragonfruit/gd_board.cpp
@@ -42,7 +42,7 @@ void gd_board_init(gd_board *b){
     b->prev_sample_ms = 0;
 
     // Initialize the packet
-    b->data_packet.schema = 0;
+    b->data_packet.schema = 3;
     b->data_packet.node_addr = 0;
     b->data_packet.uptime_ms = 0;
     b->data_packet.batt_mv = 0;
@@ -255,7 +255,7 @@ static void gd_board_heartbeat_tx(struct gd_board* b){
     uint8_t payload[_GD_DEV_XBEE_BUFSIZE_];
     struct gd_heartbeat_packet hb_packet;
 
-    hb_packet.schema = 5;
+    hb_packet.schema = 0;
     hb_packet.uptime_ms = millis();
     hb_packet.batt_mv = gd_dev_batt_read();
     hb_packet.node_addr = gd_dev_eeprom_naddr_read();


### PR DESCRIPTION
Changed schema values to:
0 = heartbeat packets
1 = generation apple
2 = generation cranberry
3 = generation dragonfruit