### PR TITLE
Add utility to burn node id

### DIFF
--- a/utils/burn_node_id/.gitignore
+++ b/utils/burn_node_id/.gitignore
@@ -1,0 +1,1 @@
+.pioenvs

--- a/utils/burn_node_id/.travis.yml
+++ b/utils/burn_node_id/.travis.yml
@@ -1,0 +1,65 @@
+# Continuous Integration (CI) is the practice, in software
+# engineering, of merging all developer working copies with a shared mainline
+# several times a day < http://docs.platformio.org/en/stable/ci/index.html >
+#
+# Documentation:
+#
+# * Travis CI Embedded Builds with PlatformIO
+#   < https://docs.travis-ci.com/user/integration/platformio/ >
+#
+# * PlatformIO integration with Travis CI
+#   < http://docs.platformio.org/en/stable/ci/travis.html >
+#
+# * User Guide for `platformio ci` command
+#   < http://docs.platformio.org/en/stable/userguide/cmd_ci.html >
+#
+#
+# Please choice one of the following templates (proposed below) and uncomment
+# it (remove "# " before each line) or use own configuration according to the
+# Travis CI documentation (see above).
+#
+
+
+#
+# Template #1: General project. Test it using existing `platformio.ini`.
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio run
+
+
+#
+# Template #2: The project is intended to by used as a library with examples
+#
+
+# language: python
+# python:
+#     - "2.7"
+#
+# sudo: false
+# cache:
+#     directories:
+#         - "~/.platformio"
+#
+# env:
+#     - PLATFORMIO_CI_SRC=path/to/test/file.c
+#     - PLATFORMIO_CI_SRC=examples/file.ino
+#     - PLATFORMIO_CI_SRC=path/to/test/directory
+#
+# install:
+#     - pip install -U platformio
+#
+# script:
+#     - platformio ci --lib="." --board=TYPE_1 --board=TYPE_2 --board=TYPE_N

--- a/utils/burn_node_id/README.md
+++ b/utils/burn_node_id/README.md
@@ -1,0 +1,5 @@
+burn_node_id
+
+This is a small utility that will help you burn a node ID onto the MCU's EEPROM.
+Compile and upload this program onto the MCU, open the serial port in your favorite
+software and then follow the instructions that get printed out.

--- a/utils/burn_node_id/README.md
+++ b/utils/burn_node_id/README.md
@@ -1,5 +1,15 @@
-burn_node_id
+# burn_node_id
 
 This is a small utility that will help you burn a node ID onto the MCU's EEPROM.
 Compile and upload this program onto the MCU, open the serial port in your favorite
 software and then follow the instructions that get printed out.
+
+## Compiling:
+
+This program can be compiled either by using the arduino IDE or platformio.
+
+1. To compile using platformio, run `make`
+2. To compile using the Arduino IDE, open the file in the burn_node_id folder.
+
+
+

--- a/utils/burn_node_id/burn_node_id/burn_node_id.ino
+++ b/utils/burn_node_id/burn_node_id/burn_node_id.ino
@@ -72,7 +72,7 @@ void loop(){
                     low = number & 0xff;
                     Serial.println(high, BIN);
                     Serial.println(low, BIN);
-                    
+
                     Serial.println("Burning Node ID to address 2 and 3");
                     EEPROM.write(2,low);
                     EEPROM.write(3,high);
@@ -105,7 +105,7 @@ void loop(){
 }
 
 void printIntro(){
-    Serial.println("REIS Weatherbox Node ID burn program loaded.");
+    Serial.println("SCEL Weatherbox Node ID burn program loaded.");
     Serial.print("This program will write to the arduino EEPROM");
     Serial.print("which is a part of memory that is persistant through");
     Serial.print("Shutdowns. This means that we will be able to burn the");

--- a/utils/burn_node_id/lib/readme.txt
+++ b/utils/burn_node_id/lib/readme.txt
@@ -1,0 +1,38 @@
+
+This directory is intended for the project specific (private) libraries.
+PlatformIO will compile them to static libraries and link to executable file.
+
+The source code of each library should be placed in separate directory, like
+"lib/private_lib/[here are source files]".
+
+For example, see how can be organized `Foo` and `Bar` libraries:
+
+|--lib
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |- readme.txt --> THIS FILE
+|- platformio.ini
+|--src
+   |- main.c
+
+Then in `src/main.c` you should use:
+
+#include <Foo.h>
+#include <Bar.h>
+
+// rest H/C/CPP code
+
+PlatformIO will find your libraries automatically, configure preprocessor's
+include paths and build them.
+
+See additional options for PlatformIO Library Dependency Finder `lib_*`:
+
+http://docs.platformio.org/en/stable/projectconf.html#lib-install
+

--- a/utils/burn_node_id/makefile
+++ b/utils/burn_node_id/makefile
@@ -1,0 +1,4 @@
+all:
+	platformio run
+upload:
+	platformio run --target upload

--- a/utils/burn_node_id/platformio.ini
+++ b/utils/burn_node_id/platformio.ini
@@ -1,0 +1,11 @@
+#
+# PlatformIO Project Configuration File
+#
+# Please make sure to read documentation with examples first
+# http://docs.platformio.org/en/stable/projectconf.html
+#
+
+[env:default]
+platform = atmelavr
+framework = arduino
+board = uno

--- a/utils/burn_node_id/platformio.ini
+++ b/utils/burn_node_id/platformio.ini
@@ -5,6 +5,9 @@
 # http://docs.platformio.org/en/stable/projectconf.html
 #
 
+[platformio]
+src_dir = burn_node_id
+
 [env:default]
 platform = atmelavr
 framework = arduino

--- a/utils/burn_node_id/src/burn_node_id.ino
+++ b/utils/burn_node_id/src/burn_node_id.ino
@@ -1,0 +1,123 @@
+/*
+ *
+ * burn_node_id.ino
+ *
+ * Writes the specified node id into the arduino EEProm
+ *
+ */
+
+#include <EEPROM.h>
+#define DEBUG
+
+void setup() {
+    Serial.begin(9600);
+}
+void loop(){
+    unsigned int id = 0;
+    char incomingByte[4];
+
+    int rawString = 0;
+    int number = 0;
+    int i = 0;
+    int invalid = 0;
+    int done = 0;
+    Serial.print("Current device's node id: ");
+    Serial.println( (EEPROM.read(2) | (EEPROM.read(3)<<8)) );
+
+    Serial.println("Please enter the node id to burn:");
+
+    while(incomingByte[i] != '\n') {
+        if(Serial.available() > 0){
+            incomingByte[i] = Serial.read();
+            #ifdef DEBUG
+            Serial.print(i);
+            Serial.print(" ");
+            Serial.print("I recieved: ");
+            Serial.println(incomingByte[i]);
+            #endif
+            if(i > 4){
+                invalid = 1;
+                break;
+            }
+            else if(i > 3 && (incomingByte[i] !='\n')){
+                //Serial.println("Invalid input.");
+                invalid = 1;
+                break;
+            }
+            else if(incomingByte[i] == '\n') break;
+            i++;
+        }
+
+
+    }
+    if(invalid == 0){
+        incomingByte[i] = '\0';
+        number = atoi(incomingByte);
+        Serial.print("You entered: ");
+        Serial.println(number);
+        Serial.print("Are you sure that you want to set this ");
+        Serial.print("device to Node ID ");
+        Serial.print(number);
+        Serial.print(" (Y/N)?: ");
+        Serial.println();
+
+        while(done == 0){
+            if(Serial.available() > 0){
+                incomingByte[0] = Serial.read();
+                if(incomingByte[0] == 'Y'){
+                    uint8_t high;
+                    uint8_t low;
+                    int test;
+                    high = (uint8_t)(number >> 8);
+                    low = number & 0xff;
+                    Serial.println(high, BIN);
+                    Serial.println(low, BIN);
+                    
+                    Serial.println("Burning Node ID to address 2 and 3");
+                    EEPROM.write(2,low);
+                    EEPROM.write(3,high);
+                    Serial.println("Done");
+                    Serial.println("Verify that the bytes are correct");
+                    test = EEPROM.read(2) | (EEPROM.read(3)<<8);
+                    Serial.print("Read node ID: ");
+                    Serial.println(test);
+
+                    done = 1;
+                    break;
+                }
+                else if(incomingByte[0] == 'N'){
+                    Serial.println("Cancel Burning");
+                    done = 1;
+                    break;
+                }
+            }
+        }
+    }
+    else{
+        #ifdef DEBUG
+        Serial.println("Invalid input.");
+        #endif
+        while(Serial.available() > 0) Serial.read();
+    }
+    Serial.println("Finish");
+    while(1);
+
+}
+
+void printIntro(){
+    Serial.println("REIS Weatherbox Node ID burn program loaded.");
+    Serial.print("This program will write to the arduino EEPROM");
+    Serial.print("which is a part of memory that is persistant through");
+    Serial.print("Shutdowns. This means that we will be able to burn the");
+    Serial.print("node IDs and read them at startup from each weatherbox.");
+    Serial.println();
+    Serial.println();
+    Serial.print("**A word of caution**: the EEPROM memory has only");
+    Serial.print("around 100,000 write/erase cycles, so be careful");
+    Serial.print("about how often you write to them.");
+
+    Serial.println();
+    Serial.println();
+}
+
+


### PR DESCRIPTION
This provides a small utility to allow users to burn a node ID to the address of the EEPROM on the MCU.