### PR TITLE
Added DTR, RSSI, and Xbee sleep pin to Dragonfruit

### DIFF
--- a/src/gen_dragonfruit/gd_dev_xbee.cpp
+++ b/src/gen_dragonfruit/gd_dev_xbee.cpp
@@ -7,14 +7,20 @@ void gd_dev_xbee_open(void)
     // Enable voltage regulator pin to power the Xbee 
     digitalWrite(3, HIGH);
 
-    // Enable DTR pin as output
+    // Configure pin connected to DTR on XBee
+    // Since in router mode we don't care what the output is
+    // so we can drive this signal LOW by default
     pinMode(A1, OUTPUT);
     digitalWrite(A1, LOW);
 
-    // Set RSSI pin as input
+    // Configure pin connected to RSSI on XBee
+    // Since RSSI pin is set to output on XBee, set the RSSI pin to
+    // input on MCU
     pinMode(A2, INPUT);
 
-    // Set Xbee sleep pin as input
+    // Configure pin connected to XBee sleep pin on XBee
+    // Since the XBee sleep pin is set to output on XBee, set 
+    // the pin to input on MCU
     pinMode(A3, INPUT);
 }
 

--- a/src/gen_dragonfruit/gd_dev_xbee.cpp
+++ b/src/gen_dragonfruit/gd_dev_xbee.cpp
@@ -6,6 +6,16 @@ void gd_dev_xbee_open(void)
     xbee.begin(soft_serial);
     // Enable voltage regulator pin to power the Xbee 
     digitalWrite(3, HIGH);
+
+    // Enable DTR pin as output
+    pinMode(A1, OUTPUT);
+    digitalWrite(A1, LOW);
+
+    // Set RSSI pin as input
+    pinMode(A2, INPUT);
+
+    // Set Xbee sleep pin as input
+    pinMode(A3, INPUT);
 }
 
 int gd_dev_xbee_avail(void)


### PR DESCRIPTION
Set the DTR pin as output and as logical low. Since the XBee is in router mode, the output doesn't matter so we can drive this signal to LOW.

Set RSSI pin as input. Since the RSSI pin is set to output on XBee, we correspondingly set the RSSI pin to input on the MCU.

Set Xbee_On/Sleep pin as input to idle the XBee. Similarly, since the Xbee_On/Sleep pin is set to output on the XBee, we set the pin to input on the MCU.