### PR TITLE
Fix scaling factor for solar irradiance.

### DIFF
--- a/src/gen_cranberry/gc_dev_apogee_SP212.cpp
+++ b/src/gen_cranberry/gc_dev_apogee_SP212.cpp
@@ -10,7 +10,7 @@ uint16_t gc_dev_apogee_SP212_solar_irr_read(void){
     uint16_t value = 4000;
 
     #ifndef SEN_STUB
-    value = ((float)adc.readADC_SingleEnded(0)*188.0)/(1000.0)*(4.0/3.3);
+    value = ((float)adc.readADC_SingleEnded(0)*188.0)/(1000.0)*(5.0/3.3);
     #endif
 
     return value;

--- a/src/gen_cranberry/gc_dev_apogee_SP212.cpp
+++ b/src/gen_cranberry/gc_dev_apogee_SP212.cpp
@@ -10,7 +10,7 @@ uint16_t gc_dev_apogee_SP212_solar_irr_read(void){
     uint16_t value = 4000;
 
     #ifndef SEN_STUB
-    value = ((float)adc.readADC_SingleEnded(0)*188.0)/(1000.0)*(5.0/3.3);
+    value = ((float)adc.readADC_SingleEnded(0)*188.0)/(1000.0);
     #endif
 
     return value;


### PR DESCRIPTION
After discussion in meeting on Nov. 10th, 2016, we found that
the scaling factor is incorrect. The scaling factor has been changed
from 4.0/3.3 to 5.0/3.3.