### PR TITLE
Fix to dragonfruit solar panel and battery pins

### DIFF
--- a/src/gen_dragonfruit/gd_dev_batt.h
+++ b/src/gen_dragonfruit/gd_dev_batt.h
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 
-#define _PIN_GD_BATT_ A0
+#define _PIN_GD_BATT_ A7
 
 #ifndef GD_DEV_BATT_H
 #define GD_DEV_BATT_H

--- a/src/gen_dragonfruit/gd_dev_spanel.h
+++ b/src/gen_dragonfruit/gd_dev_spanel.h
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 
-#define _PIN_GD_SPANEL_ A6 
+#define _PIN_GD_SPANEL_ A0
 
 #ifndef GD_DEV_SPANEL
 #define GD_DEV_SPANEL


### PR DESCRIPTION
On Dragonfruit, there were already connections for solar panel and battery readings made on version 2. Previously it was assumed there was no connections to the MCU so a wire was inserted thus VBATT was connected to A0 and SOLAR_TEST was connected to A6. Since there are already connections, the wire on the board was removed and the pins are now correspondingly changed to A7 for VBATT and A0 for SOLAR_TEST.