### PR TITLE
Add stub heartbeat (stub_hb) builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -15,8 +15,14 @@
 #
 # Stub
 # A stub build that forces the sensors to return 'good' values
-# and permanently turn on the heartbeat module. Useful for
-# debugging network connectivity.
+# This is useful for quickly checking if programming logic is correct,
+# without having to worry too much about sensor hardware. UART writes
+# should still be active, including software serial.
+#
+# Stub_hb
+# This is the same as the stub build, but with heartbeat packets
+# **permantently** turned on. This build is especially useful for
+# testing network connectivity since UART writes are still enabled.
 #
 
 # ============================
@@ -36,6 +42,12 @@ build_flags = -DGA
 
 
 [env:ga_stub]
+platform = atmelavr
+framework = arduino
+board = uno
+build_flags = -DGA -DSEN_STUB
+
+[env:ga_stub_hb]
 platform = atmelavr
 framework = arduino
 board = uno
@@ -59,6 +71,12 @@ build_flags = -DGC
 platform = atmelavr
 framework = arduino
 board = pro8MHzatmega328
+build_flags = -DGC -DSEN_STUB
+
+[env:gc_stub_hb]
+platform = atmelavr
+framework = arduino
+board = pro8MHzatmega328
 build_flags = -DGC -DSEN_STUB -DHB_FOREVER
 
 
@@ -77,6 +95,12 @@ board = uno
 build_flags = -DGD
 
 [env:gd_stub]
+platform = atmelavr
+framework = arduino
+board = uno
+build_flags = -DGD -DSEN_STUB
+
+[env:gd_stub_hb]
 platform = atmelavr
 framework = arduino
 board = uno


### PR DESCRIPTION
Normal stub builds should behave almost exactly like
normal builds, except that all calls to hardware are hardcoded
with default values. So breaking out the permanent heartbeat feature
into another build seems appropriate.

The normal stub builds are particular useful because we needed
a device that was constantly on to ensure that the gateway saw traffic
on the network. Since we have devices that go down, we needed a control
to compare against to see if it was an error with the gateway or
an error with a physical sensor node.